### PR TITLE
Do not include the feeNumerator on the collector's state.

### DIFF
--- a/test/FeeRewardsManager.t.sol
+++ b/test/FeeRewardsManager.t.sol
@@ -213,4 +213,34 @@ contract FeeRewardsTest is Test {
         vm.expectRevert("Invalid fee numerator");
         feeRewardsManager.changeFeeNumerator(payable(addr), 10_001);
     }
+
+    function testChangeFeeNumeratorAndWatchPredictedContract() public {
+        address withdrawalCredential = address(100);
+        vm.deal(address(0), 10 ether);
+        address derivedAddr = feeRewardsManager.predictFeeContractAddress(
+            withdrawalCredential
+        );
+        feeRewardsManager.changeDefaultFee(10_000);
+        address derivedAddr2 = feeRewardsManager.predictFeeContractAddress(
+            withdrawalCredential
+        );
+        assert(derivedAddr == derivedAddr2);
+    }
+
+    function testDerivedAddress() public {
+        address withdrawalCredential = address(100);
+        vm.deal(address(0), 10 ether);
+        address derivedAddr = feeRewardsManager.predictFeeContractAddress(
+            withdrawalCredential
+        );
+
+        vm.deal(derivedAddr, 10 ether);
+
+        address payable addr = feeRewardsManager.createFeeContract(
+            withdrawalCredential
+        );
+
+        //derived address matches the function to get one.
+        assertEq(derivedAddr, addr);
+    }
 }


### PR DESCRIPTION
1. The user uses this endpoint to calculate the RewardsCollector address to pass to ChorusDeposit.deposit as withdrawalCredential before deploying this RewardsCollector contract
2. The owner of FeeRewardsManager changes the defaultFeeNumerator

The user would not be able to deploy the RewardsCollector at the predicted address since defaultFeeNumerator has been changed so the fees get locked in that address unless the owner changes the defaultFeeNumerator back to the value at step 1. so that the user would be able to deploy the correct RewardsCollector.